### PR TITLE
fix(docker): 修复 NAS 部署相关问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -124,9 +124,9 @@ ENV UMASK=002
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# 健康检查
+# 健康检查（使用环境变量 PORT）
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3001/api/stats', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
+  CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 3001) + '/api/stats', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
 
 # 使用入口脚本启动
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/Dockerfile.gha
+++ b/Dockerfile.gha
@@ -93,9 +93,9 @@ ENV UMASK=002
 COPY docker-entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# 健康检查
+# 健康检查（使用环境变量 PORT）
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:3001/api/stats', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
+  CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 3001) + '/api/stats', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
 
 # 使用入口脚本启动
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -17,9 +17,9 @@ if [ -z "$GROUP_NAME" ]; then
     # GID 未被占用，创建新组 cloudimgs
     addgroup -g "$PGID" cloudimgs
     GROUP_NAME=cloudimgs
-else
-    echo "GID $PGID already in use by group '$GROUP_NAME', utilizing it."
+    echo "[INFO] Created new group 'cloudimgs' with GID $PGID"
 fi
+# 如果 GID 已被占用，静默使用已有组（这是 NAS 上的正常情况）
 
 # 处理用户
 # 检查 UID 是否已被占用
@@ -28,10 +28,9 @@ if [ -z "$USER_NAME" ]; then
     # UID 未被占用，创建新用户 cloudimgs
     adduser -D -H -u "$PUID" -G "$GROUP_NAME" cloudimgs
     USER_NAME=cloudimgs
-else
-    echo "UID $PUID already in use by user '$USER_NAME', utilizing it."
-    # 如果用户组不匹配，尝试修正（非必须，su-exec 可以指定组）
+    echo "[INFO] Created new user 'cloudimgs' with UID $PUID"
 fi
+# 如果 UID 已被占用，静默使用已有用户（这是 NAS 上的正常情况）
 
 # 确保目录存在
 mkdir -p "$STORAGE_PATH" logs


### PR DESCRIPTION
1. 静默 GID/UID 已存在的信息消息（避免 NAS Container Manager 警告）
2. 修复 HEALTHCHECK 使用动态 PORT 环境变量（支持自定义端口）