### PR TITLE
feat(docker): 支持 main 分支自动构建 Docker 镜像

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,6 +2,8 @@ name: Docker Publish
 
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*"
   workflow_dispatch:
@@ -27,6 +29,10 @@ on:
         options:
           - linux/amd64
           - linux/amd64,linux/arm64
+
+concurrency:
+  group: docker-publish-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:


### PR DESCRIPTION
## 变更说明

为 Docker 构建流程添加 main 分支支持，使用户可以通过 `:main` 标签获取最新开发版本的镜像。

## 具体改动

1. **添加 main 分支触发条件**：每次推送到 main 分支时自动构建 Docker 镜像
2. **添加并发控制**：使用 `cancel-in-progress` 确保多次快速推送只保留最后一次构建，避免资源浪费

## 为什么需要这个功能？

| 理由 | 说明 |
|------|------|
| **用户需求** | 很多 NAS 用户希望尝试最新功能，但不具备自行编译能力 |
| **降低测试门槛** | 新功能可以更快获得用户反馈，加速迭代 |
| **行业惯例** | 大多数开源 Docker 项目都提供 `latest`（稳定）+ `main`/`dev`（开发）双版本 |

## 资源影响

- ✅ 添加了并发控制，多次快速推送只保留最后一次构建
- ✅ GitHub Actions 对公开仓库完全免费
- ✅ `:main` 标签会自动覆盖，不会累积存储空间

## 使用方式

变更后用户可以选择：

```yaml
# 稳定版（推荐日常使用）
image: qazzxxx/cloudimgs:latest

# 开发版（尝鲜最新功能，可能不稳定）
image: qazzxxx/cloudimgs:main