### PR TITLE
fix: 切换文件夹时重置滚动位置到顶部

### DIFF
--- a/client/src/components/ImageGallery.js
+++ b/client/src/components/ImageGallery.js
@@ -898,6 +898,9 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
           setHasMore(true);
           setCurrentPage(1);
           setPendingDir(null);
+          
+          // Reset scroll position to top when switching folders
+          window.scrollTo(0, 0);
       }
   }, [dir]);
 


### PR DESCRIPTION
修复了切换相册文件夹时，页面保持上一个文件夹滚动位置的问题。

## 变更内容
- 在目录切换的 useEffect 中添加 `window.scrollTo(0, 0) ` 来重置滚动位置

## 测试
- 在任意相册滚动到底部
- 切换到另一个相册
- 验证页面滚动位置已重置到顶部