### PR TITLE
fix: 修复目录下拉菜单滚动穿透问题

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -179,6 +179,12 @@ function App() {
     ::-webkit-scrollbar-thumb:hover {
       background: ${currentTheme === 'dark' ? '#555' : '#999'};
     }
+    
+    /* Prevent dropdown scroll from affecting main page */
+    .directory-selector-dropdown .rc-virtual-list-holder {
+      overflow-y: auto !important;
+      overscroll-behavior: contain;
+    }
   `;
 
   return (

--- a/client/src/components/DirectorySelector.js
+++ b/client/src/components/DirectorySelector.js
@@ -106,6 +106,7 @@ const DirectorySelector = ({
           return optionText.toLowerCase().indexOf(input.toLowerCase()) >= 0;
         }}
         notFoundContent={loading ? "加载中..." : "暂无相册"}
+        popupClassName="directory-selector-dropdown"
         dropdownRender={(menu) => (
           <div>
             {menu}


### PR DESCRIPTION
## 问题描述
在目录选择下拉菜单中使用鼠标滚轮滚动时，主页面的瀑布流会同时滚动，影响用户体验。

## 问题根因
Ant Design Select 使用虚拟列表 (`rc-virtual-list`) 渲染下拉选项，该组件内部使用 `overflow: hidden` + JavaScript 模拟滚动。由于容器不是原生滚动容器，`wheel` 事件会冒泡到 `window` 导致页面滚动。

## 解决方案
1. 在 [DirectorySelector] 添加 `popupClassName` 标识下拉菜单
2. 添加 CSS 规则强制虚拟列表使用原生滚动 (`overflow-y: auto !important`)
3. 使用 `overscroll-behavior: contain` 阻止滚动事件穿透到主页面

## 变更文件
- [client/src/components/DirectorySelector.js]: 添加 popupClassName
- [client/src/App.js]: 添加全局 CSS 规则

## 测试步骤
1. 滚动主页面到中间位置
2. 点击目录选择下拉菜单
3. 在下拉菜单内使用鼠标滚轮滚动
4. **预期结果**：主页面保持不动，只有下拉菜单内部滚动