### PR TITLE
fix: 解决密码保护下健康检查失败和 npm 权限问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,7 +126,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # 健康检查（使用环境变量 PORT）
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 3001) + '/api/stats', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
+  CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 3001) + '/api/health', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
 
 # 使用入口脚本启动
 ENTRYPOINT ["docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,8 +38,10 @@ mkdir -p "$STORAGE_PATH" logs
 # 修正权限（如果使用 root 启动容器，则修正所有权）
 if [ "$(id -u)" = "0" ]; then
     chown -R "$USER_NAME:$GROUP_NAME" "$STORAGE_PATH" logs /app
+    
     # 使用 su-exec 降权运行应用
-    exec su-exec "$USER_NAME:$GROUP_NAME" "$@"
+    # 设置 HOME=/app 避免 npm 日志权限问题（NAS 映射用户可能没有主目录）
+    exec su-exec "$USER_NAME:$GROUP_NAME" env HOME=/app "$@"
 else
     # 如果已经是普通用户，直接运行
     exec "$@"

--- a/server/index.js
+++ b/server/index.js
@@ -62,6 +62,11 @@ app.use(express.json({ limit: '50mb' })); // 增加限制以支持大型 base64 
 app.use(express.static(path.join(__dirname, "../client/build")));
 app.enable("trust proxy");
 
+// 健康检查接口 (不需要密码验证)
+app.get("/api/health", (req, res) => {
+  res.status(200).json({ status: "ok" });
+});
+
 function getProtocol(req) {
   const proto = req.headers["x-forwarded-proto"] || req.protocol;
   if (Array.isArray(proto)) return proto[0];


### PR DESCRIPTION
在启用密码保护后，容器出现两个问题：

1. **健康检查失败**：`HEALTHCHECK` 使用 `/api/stats` 接口，该接口受密码保护，导致健康检查返回 401，容器被标记为 `unhealthy`
2. **npm 权限错误**：`cloudimgs` 用户没有主目录写权限，npm 无法写入日志文件

## 修改内容

| 文件 | 修改 |
|------|------|
| [server/index.js] | 新增 `/api/health` 无认证健康检查接口 |
| [Dockerfile] | `HEALTHCHECK` 改用 `/api/health` |
| [docker-entrypoint.sh] | 设置 `HOME=/app` 避免 npm 写入权限错误 |

## 测试验证

- ✅ `/api/health` 返回 200 OK（无需密码）
- ✅ `/api/stats` 返回 401（密码保护生效）
- ✅ 容器日志无 `npm error`
- ✅ `HOME` 环境变量正确设置为 `/app`
- ✅ 未创建多余的 `/home/cloudimgs` 目录