### PR TITLE
fix: 修复 Docker 健康检查和 latest 标签问题

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,7 +84,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Extract metadata for Docker Hub
         id: meta-dockerhub
@@ -96,7 +96,7 @@ jobs:
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
-            type=raw,value=latest
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
 
       - name: Build and push to GitHub Packages
         if: github.event.inputs.registry == 'ghcr' || github.event.inputs.registry == 'both' || github.event_name == 'push'

--- a/Dockerfile.gha
+++ b/Dockerfile.gha
@@ -95,7 +95,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
 # 健康检查（使用环境变量 PORT）
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-  CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 3001) + '/api/stats', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
+  CMD node -e "require('http').get('http://localhost:' + (process.env.PORT || 3001) + '/api/health', (res) => { process.exit(res.statusCode === 200 ? 0 : 1) })"
 
 # 使用入口脚本启动
 ENTRYPOINT ["docker-entrypoint.sh"]


### PR DESCRIPTION
## 问题描述

修复两个 Docker 相关的问题：

### 1. 健康检查端点未同步 (来自 PR #14 的遗漏)

[Dockerfile.gha] 的 HEALTHCHECK 仍然使用 `/api/stats`，而 [Dockerfile] 已更新为 `/api/health`。这导致 GitHub Actions 构建的镜像在启用密码保护时容器状态为 unhealthy。

### 2. latest 标签逻辑错误 (来自 PR #11 的遗漏)

当前配置会在每次 `main` 分支推送时都添加 `latest` 标签，导致 `main` 和 `latest` 指向同一个镜像。

**期望行为**：
- `latest` = 稳定版，只在发布版本 tag 时更新
- `main` = 开发版，每次 main 分支推送时更新

## 修改内容

| 文件 | 修改 |
|------|------|
| [Dockerfile.gha] | 健康检查端点改为 `/api/health` |
| [.github/workflows/docker-publish.yml] | `latest` 标签只在 `refs/tags/v*` 时添加 |

## 测试

- 合并后推送 main 分支：只生成 `main` 标签
- 发布新版本 tag：生成版本号 + `latest` 标签