### PR TITLE
fix: 修复预览模式加载更多图片时顺序不稳定的问题

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -873,8 +873,12 @@ app.get("/api/images", requirePassword, async (req, res) => {
     // 获取所有图片
     let images = await getAllImages(dir, albumPassword);
 
-    // 按上传时间倒序排列
-    images.sort((a, b) => new Date(b.uploadTime) - new Date(a.uploadTime));
+    // 按上传时间倒序排列，使用 filename 升序作为次要排序键保证稳定性
+    images.sort((a, b) => {
+      const timeDiff = new Date(b.uploadTime) - new Date(a.uploadTime);
+      if (timeDiff !== 0) return timeDiff;
+      return a.filename.localeCompare(b.filename);
+    });
 
     // 搜索过滤
     if (search) {
@@ -1851,8 +1855,12 @@ app.get("/api/share/access", async (req, res) => {
         // Token valid, return content
         let images = await getAllImages(dir);
         
-        // Sort
-        images.sort((a, b) => new Date(b.uploadTime) - new Date(a.uploadTime));
+        // Sort - 按上传时间倒序，filename 升序作为次要排序键保证稳定性
+        images.sort((a, b) => {
+          const timeDiff = new Date(b.uploadTime) - new Date(a.uploadTime);
+          if (timeDiff !== 0) return timeDiff;
+          return a.filename.localeCompare(b.filename);
+        });
 
         // Pagination
         const page = parseInt(req.query.page) || 1;


### PR DESCRIPTION
### 问题描述

PR #15 实现的预览模式自动加载更多图片功能存在一个潜在 BUG：新加载的图片顺序有一定概率不符合正常渲染的图片顺序。

### 根本原因

后端 `/api/images` 端点在分页时仅使用 `uploadTime` 进行降序排序。当多张图片的 `uploadTime` 相同时（批量上传或毫秒级精度重复），JavaScript 的 `sort()` 算法不保证稳定性，导致分页边界处图片顺序可能不一致。

### 解决方案

在后端排序逻辑中添加 [filename]升序作为次要排序键，确保分页结果的确定性。

### 变更内容

- **[server/index.js]**:
  - `/api/images` 端点：添加 filename 升序作为次要排序键
  - `/api/share/access` 端点：添加 filename 升序作为次要排序键

### 测试验证

1. 上传多张图片（确保有些图片上传时间相近或相同）
2. 多次刷新页面，确认图片顺序一致
3. 在预览模式中连续按"下一张"，跨越分页边界时顺序平滑无跳跃