### PR TITLE
fix: 优化相册管理弹窗性能和交互体验

### DIFF
--- a/client/src/components/ImageGallery.js
+++ b/client/src/components/ImageGallery.js
@@ -962,6 +962,7 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
   }, [hasMore, loading, loadingMore, images.length]);
 
   const [previewLocation, setPreviewLocation] = useState("");
+  const [menuOpen, setMenuOpen] = useState(false);
 
   // Effect for fetching address in Preview Modal
   useEffect(() => {
@@ -1681,12 +1682,18 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
             }}
           />
           <Popover
+            open={menuOpen}
+            onOpenChange={setMenuOpen}
             content={
               <div style={{ padding: 4 }}>
                   <Button
                     type="text"
                     icon={<FolderOutlined />}
-                    onClick={() => setAlbumManagerVisible(true)}
+                    onClick={() => {
+                        setMenuOpen(false);
+                        // Defer modal opening to let popover close smoothly
+                        setTimeout(() => setAlbumManagerVisible(true), 300);
+                    }}
                     style={{ 
                         width: "100%", 
                         textAlign: "left", 
@@ -1701,7 +1708,10 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
                   <Button
                     type="text"
                     icon={<CodeOutlined />}
-                    onClick={() => setSvgToolVisible(true)}
+                    onClick={() => {
+                        setMenuOpen(false);
+                        setSvgToolVisible(true);
+                    }}
                     style={{ 
                         width: "100%", 
                         textAlign: "left", 
@@ -1716,7 +1726,10 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
                   <Button
                     type="text"
                     icon={<ApiOutlined />}
-                    onClick={() => window.open("/opendocs", "_blank")}
+                    onClick={() => {
+                         setMenuOpen(false);
+                         window.open("/opendocs", "_blank");
+                    }}
                     style={{ 
                         width: "100%", 
                         textAlign: "left", 


### PR DESCRIPTION

## 问题描述
1. **菜单残留问题**：点击顶部菜单"相册管理"按钮后，下拉菜单（Popover）无法及时消失，会长时间悬浮在屏幕上，直到 Modal 完全渲染后才消失，造成视觉残留。
2. **缩略图渲染性能问题**：相册卡片使用了复杂的 CSS 3D 变换效果（`perspective`、`rotate`、`translateX/Y`、`scale`）来实现堆叠缩略图效果，且原有的 `transition: all 0.4s` 对所有属性进行动画，导致悬停交互时浏览器需要进行大量的重排和重绘，造成卡顿。
## 解决方案
1. 将顶部菜单 Popover 改为受控组件，并延迟 300ms 打开 Modal，确保菜单先关闭。
2. 移除客户端分页逻辑，简化状态管理。
3. 禁用 Modal 的进出动画，减少渲染开销。
4. 为相册卡片添加 CSS 性能优化属性，限制重排/重绘范围。
5. 添加 `AbortController` 防止请求竞态。
## 变更内容
- [client/src/components/AlbumManager.js]:
    - 移除 `visibleCount`、`scrollContainerRef`、`isClosing` 状态
    - 移除 `handleScroll` 滚动监听和 `handleClose` 包装函数
    - 添加 `AbortController` 支持，[fetchAlbums] 接受 `abortSignal` 参数
    - 添加 `destroyOnClose`、`transitionName=""`、`maskTransitionName=""`
    - 将 `albums.slice(0, visibleCount).map` 改为 `albums.map`
    - 卡片添加 `contain: "layout style"`、`contain: "paint"`
    - 堆叠图片 `transition` 改为仅 `transform`，添加 `willChange`、`backfaceVisibility`
- [client/src/components/ImageGallery.js]:
    - 新增 `menuOpen` 状态控制 Popover
    - Popover 添加 `open={menuOpen}` 和 `onOpenChange={setMenuOpen}`
    - "相册管理"按钮延迟 300ms 打开 Modal
    - 所有菜单按钮点击时先关闭菜单
## 测试验证
1. 点击顶部菜单"相册管理"，确认菜单立即消失，无残留
2. 确认 Modal 在短暂延迟后出现（无动画），内容加载正确
3. 验证相册卡片悬停效果流畅，无卡顿
4. 快速多次开关弹窗，确认无报错或状态异常