### PR TITLE
feat: 将瀑布流缩略图宽度配置化 (THUMBNAIL_WIDTH)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ services:
       - PORT=3001
       - STORAGE_PATH=/app/uploads
       # - MAX_FILE_SIZE=10485760 # 最大文件大小，默认 10MB
+      # - THUMBNAIL_WIDTH=0 # 瀑布流缩略图宽度（像素），默认 0 表示使用原图
       # 密码保护配置（可选）
       # - PASSWORD=your_secure_password_here
 ```

--- a/client/src/components/ImageGallery.js
+++ b/client/src/components/ImageGallery.js
@@ -72,7 +72,8 @@ const ImageItem = ({
     isBatchMode,
     isSelected,
     onToggleSelect,
-    registerRef
+    registerRef,
+    thumbnailWidth = 0
 }) => {
     const [loaded, setLoaded] = useState(false);
     const {
@@ -177,7 +178,7 @@ const ImageItem = ({
                 {/* Real Image Layer */}
                 <img
                     alt={image.filename}
-                    src={image.url + "?w=400"}
+                    src={thumbnailWidth > 0 ? `${image.url}?w=${thumbnailWidth}` : image.url}
                     draggable={false}
                     loading="lazy"
                     onLoad={() => setLoaded(true)}
@@ -428,6 +429,24 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
   const [passwordPromptVisible, setPasswordPromptVisible] = useState(false);
   const [passwordInput, setPasswordInput] = useState("");
   const [pendingDir, setPendingDir] = useState(null); // The directory that required password
+
+  // Thumbnail width from config (0 = use original)
+  const [thumbnailWidth, setThumbnailWidth] = useState(0);
+
+  // Fetch config to get thumbnailWidth
+  useEffect(() => {
+    const fetchConfig = async () => {
+      try {
+        const response = await api.get("/config");
+        if (response.data.success && response.data.data?.upload?.thumbnailWidth) {
+          setThumbnailWidth(response.data.data.upload.thumbnailWidth);
+        }
+      } catch (error) {
+        console.warn("获取配置失败:", error);
+      }
+    };
+    fetchConfig();
+  }, [api]);
 
   useEffect(() => {
     if (!hoverKey) {
@@ -1917,9 +1936,11 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
                         onSelectionChange(newSet);
                     }}
                     registerRef={registerRef}
+                    thumbnailWidth={thumbnailWidth}
                   />
                 )}
               />
+
             </div>
           ))}
           <div ref={loadMoreRef} style={{ height: 20 }} />

--- a/config.js
+++ b/config.js
@@ -30,6 +30,11 @@ module.exports = {
 
     // 文件名冲突时的处理策略: 'timestamp' | 'counter' | 'overwrite'
     duplicateStrategy: process.env.DUPLICATE_STRATEGY || "timestamp",
+
+    // 瀑布流缩略图宽度（像素），0 表示使用原图
+    thumbnailWidth: process.env.THUMBNAIL_WIDTH
+      ? parseInt(process.env.THUMBNAIL_WIDTH)
+      : 0,
   },
 
   // 存储配置

--- a/env.example
+++ b/env.example
@@ -8,6 +8,7 @@ STORAGE_PATH=./uploads
 # 上传配置（可选，默认值在 config.js 中设置）
 # MAX_FILE_SIZE=10485760  # 10MB in bytes
 # ALLOWED_EXTENSIONS=.jpg,.jpeg,.png,.gif,.webp,.bmp,.svg
+# THUMBNAIL_WIDTH=0  # 瀑布流缩略图宽度（像素），0 表示使用原图，推荐值 400-800
 
 # 密码保护配置（可选）
 # 设置此环境变量将启用密码保护，用户需要输入密码才能访问系统

--- a/server/index.js
+++ b/server/index.js
@@ -1985,6 +1985,7 @@ app.get("/api/config", (req, res) => {
           .map((ext) => ext.replace(".", ""))
           .join(", ")
           .toUpperCase(),
+        thumbnailWidth: config.upload.thumbnailWidth || 0,
       },
       storage: {
         path: config.storage.path,


### PR DESCRIPTION
### 背景

图床项目的用户群体多样：公网部署时需要节省带宽，而 NAS 本地部署时更看重图片清晰度。

本次修改将瀑布流缩略图宽度改为可配置，满足不同场景的需求。

### 解决思路


考虑到不同用户有不同的使用场景和偏好，本 PR 将缩略图宽度改为可配置项，让用户根据自己的实际情况灵活选择：

- **公网部署用户**：可设置 `THUMBNAIL_WIDTH=400` 或 `600`，节省带宽
- **NAS/局域网用户**：保持默认 `0`，使用原图，获得最佳清晰度

### 改动内容

| 文件 | 变更 |
|------|------|
| `config.js` | 新增 `thumbnailWidth` 配置项，默认 `0` |
| `server/index.js` | 通过 `/api/config` 暴露配置 |
| `client/src/components/ImageGallery.js` | 根据配置动态决定是否添加宽度参数 |
| `env.example` | 添加配置说明 |
| `README.md` | docker-compose 示例中添加环境变量注释 |

### 使用方式

```yaml
environment:
  - THUMBNAIL_WIDTH=0    # 默认，使用原图
  # - THUMBNAIL_WIDTH=600  # 可选，压缩到指定宽度
```

### 兼容性

- ✅ 默认行为使用原图，对现有用户无影响
- ✅ 设置 `THUMBNAIL_WIDTH=400` 可恢复原提交行为
- ✅ 无破坏性变更
