### PR TITLE
fix(目录选择器): 修复@eaDir显示和首次登录渲染问题

### DIFF
--- a/client/src/components/ImageGallery.js
+++ b/client/src/components/ImageGallery.js
@@ -1766,7 +1766,7 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
               api={api}
               bordered={false}
               size="middle"
-              refreshKey={directoryRefreshKey}
+              refreshKey={`${directoryRefreshKey}-${isAuthenticated}`}
             />
           </div>
           <div

--- a/server/index.js
+++ b/server/index.js
@@ -1603,7 +1603,7 @@ async function getDirectories(dir = "", recursive = false) {
     let currentLevelDirs = [];
     
     for (const file of files) {
-      if (file === CACHE_DIR_NAME || file === CONFIG_DIR_NAME || file === TRASH_DIR_NAME) continue;
+      if (file === CACHE_DIR_NAME || file === CONFIG_DIR_NAME || file === TRASH_DIR_NAME || file.startsWith('@')) continue;
       const filePath = path.join(absDir, file);
       const stats = await fs.stat(filePath);
       if (stats.isDirectory()) {


### PR DESCRIPTION
## 修复目录选择器的两个 Bug

### 问题描述

1. **@eaDir 目录显示问题** (由 `0092fb0` 引入): 群晖 NAS 的系统目录 `@eaDir` 会出现在目录选择器中
2. **首次登录渲染问题** (历史遗留): 用户输入密码登录后，目录选择器不会渲染目录，需要刷新页面

### 根本原因

1. **@eaDir**: 服务端 `getDirectories` 函数没有过滤以 `@` 开头的群晖系统目录
2. **首次登录**: `DirectorySelector` 的 `refreshKey` 不包含认证状态，导致登录成功后不会重新获取目录列表

### 解决方案

#### 后端 (server/index.js)

过滤所有以 `@` 开头的目录（群晖 NAS 使用 `@` 前缀标识系统目录，如 `@eaDir`、`@tmp` 等）

```diff
- if (file === CACHE_DIR_NAME || file === CONFIG_DIR_NAME || file === TRASH_DIR_NAME) continue;
+ if (file === CACHE_DIR_NAME || file === CONFIG_DIR_NAME || file === TRASH_DIR_NAME || file.startsWith('@')) continue;
```

#### 前端 (ImageGallery.js)

将 `isAuthenticated` 添加到 `refreshKey`，使得登录状态变化时触发目录列表重新加载

```diff
- refreshKey={directoryRefreshKey}
+ refreshKey={`${directoryRefreshKey}-${isAuthenticated}`}
```

### 测试

- [x] 创建 `@eaDir` 目录后不显示在选择器中
- [x] 首次登录后目录选择器正常渲染
