### PR TITLE
fix(security): 为 API 添加密码保护并实现 Cookie 认证

### DIFF
--- a/client/src/components/ApiDocs.js
+++ b/client/src/components/ApiDocs.js
@@ -300,8 +300,8 @@ const ApiDocs = () => {
            <Card type="inner" title="获取目录列表" bordered={false}>
             <div style={endpointStyle}>
               <Tag color="blue" style={methodTagStyle('GET')}>GET</Tag>
-              <Text code copyable>/api/dirs</Text>
-              <CurlButton endpoint="/api/dirs" method="GET" />
+              <Text code copyable>/api/directories</Text>
+              <CurlButton endpoint="/api/directories" method="GET" />
             </div>
             <Paragraph>
               获取当前所有的图片目录结构。

--- a/client/src/components/DirectorySelector.js
+++ b/client/src/components/DirectorySelector.js
@@ -16,6 +16,7 @@ const DirectorySelector = ({
   allowInput = true,
   api,
   refreshKey = 0,
+  enabled = true,
 }) => {
   const [directories, setDirectories] = useState([]);
   const [loading, setLoading] = useState(false);
@@ -40,8 +41,10 @@ const DirectorySelector = ({
   }, [api]);
 
   useEffect(() => {
-    fetchDirectories();
-  }, [refreshKey, fetchDirectories]);
+    if (enabled) {
+      fetchDirectories();
+    }
+  }, [refreshKey, fetchDirectories, enabled]);
 
   // Auto expand parents of the current value
   useEffect(() => {

--- a/client/src/components/ImageGallery.js
+++ b/client/src/components/ImageGallery.js
@@ -1767,6 +1767,7 @@ const ImageGallery = ({ onDelete, onRefresh, api, isAuthenticated, refreshTrigge
               bordered={false}
               size="middle"
               refreshKey={`${directoryRefreshKey}-${isAuthenticated}`}
+              enabled={isAuthenticated}
             />
           </div>
           <div

--- a/client/src/components/PasswordOverlay.js
+++ b/client/src/components/PasswordOverlay.js
@@ -43,7 +43,7 @@ const PasswordOverlay = ({ onLoginSuccess, isMobile }) => {
       }}
     >
       {/* Dynamic Background */}
-      <ScrollingBackground />
+      <ScrollingBackground usePicsum={true} />
 
       {/* Glassmorphism Overlay */}
       <div

--- a/client/src/utils/secureStorage.js
+++ b/client/src/utils/secureStorage.js
@@ -1,6 +1,6 @@
 const STORAGE_KEY = "cloudimgs_password";
 const SALT = "cloudimgs-salt-2025";
-const EXPIRATION_TIME = 24 * 60 * 60 * 1000; // 24 hours in milliseconds
+const EXPIRATION_TIME = 30 * 24 * 60 * 60 * 1000; // 30 days in milliseconds
 
 function xorCipher(input) {
   const salt = SALT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.10.0",
+        "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.6.1",
         "exifr": "^7.1.3",
@@ -774,6 +775,28 @@
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
       "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.7.tgz",
+      "integrity": "sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "0.7.2",
+        "cookie-signature": "1.0.6"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/cookie-parser/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "axios": "^1.10.0",
+    "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "dotenv": "^16.6.1",
     "exifr": "^7.1.3",


### PR DESCRIPTION
## 问题描述

1. /api/images/*、/api/files/*、/api/random 路由缺少 requirePassword 中间件，设置 PASSWORD 后仍可直接访问。
2. /api/share/access 返回的图片 URL 指向 /api/images/*，与密码保护逻辑冲突。

## 解决方案

1. 为 /api/images/*、/api/files/*、/api/random 添加 requirePassword 中间件。
2. 实现 Cookie 认证：/api/auth/verify 成功时设置 httpOnly Cookie，requirePassword 中间件增加 Cookie 读取逻辑。
3. 新增 /api/share/image/* 路由，通过 share token 验证权限。
4. /api/share/access 返回的图片 URL 改为指向 /api/share/image/*。

## 关于 /api/random 密码保护的立场

本 PR 与上游提交 fcfe00b（移除 /api/random 密码验证）存在冲突。

**Contributor 立场（基于 API 标准化设计原则）**：

/api/random 应保持密码保护，理由如下：

1. **一致性原则**：/api/random 内部调用 getAllImages() 获取图片列表，其数据来源与 /api/images 相同。若 /api/images 需要密码保护，/api/random 也应保持一致。
2. **数据暴露风险**：/api/random?format=json 返回图片元数据（路径、尺寸、上传时间），若不保护则等同于部分开放 /api/images 能力。
3. **语义清晰**：PASSWORD 环境变量的语义是保护所有敏感数据，用户的合理预期是设置密码后所有图片相关 API 均受保护。

**建议**：若需公开随机图片能力，有两种推荐方案：

1. **不设置 PASSWORD 环境变量**：系统将禁用全局密码保护，所有 API 均可直接访问，适合接入 n8n、Make 等自动化工作流平台，或部署在受信任的内网环境。

2. **设计独立的公开接口**：如 /api/public/random，明确区分公开与受保护资源，而非移除现有接口的安全保护。这符合最小权限原则，避免因单一需求而降低整体安全性。

## 变更内容

**[server/index.js]**
- 引入 cookie-parser 中间件
- CORS 配置更新为 { origin: true, credentials: true }
- requirePassword 增加 req.cookies?.access_password 检查
- /api/images/*、/api/files/*、/api/random 添加 requirePassword
- /api/auth/verify 成功时设置 httpOnly Cookie（maxAge: 30天，sameSite: lax）
- 新增 /api/share/image/* 路由
- /api/share/access 返回数据中 img.url 改为指向 /api/share/image/*
- 删除 /api/random 注释中的 "无需全局密码验证" 描述

**[client/src/components/DirectorySelector.js]**
- 新增 enabled 属性，useEffect 中仅当 enabled=true 时调用 fetchDirectories

**[client/src/components/ImageGallery.js]**
- DirectorySelector 传入 enabled={isAuthenticated}

**[client/src/components/PasswordOverlay.js]**
- ScrollingBackground 添加 usePicsum={true}

**[client/src/components/ApiDocs.js]**
- /api/dirs 修正为 /api/directories

**[client/src/utils/secureStorage.js]**
- EXPIRATION_TIME 从 24 * 60 * 60 * 1000 改为 30 * 24 * 60 * 60 * 1000

**[package.json]**
- 添加 cookie-parser: ^1.4.7

## 测试验证

1. 设置 PASSWORD 后，访问 /api/images/*、/api/files/*、/api/random 返回 401
2. 登录后 Cookie 中包含 access_password，访问上述接口正常
3. 分享链接可正常加载图片（通过 /api/share/image/* 和 token）