### PR TITLE
docs: 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,4 +141,4 @@ services:
 
 ## 📈 历史 Star | Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=qazzxxx/cloudimgs&type=date&legend=top-left)](https://www.star-history.com/#qazzxxx/cloudimgs&type=date&legend=top-left)
+[![Star History Chart](https://star-history.dera.page/svg?repos=qazzxxx/cloudimgs&type=date&legend=top-left)](https://star-history.dera.page/#qazzxxx/cloudimgs&type=date&legend=top-left)


### PR DESCRIPTION
现有 Star History 图表因 GitHub 星标接口限制已无法正常显示，本项目已接入替代数据源，可直接修复图表展示，无需任何配置。